### PR TITLE
Add CMake install command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,3 +11,4 @@ include_directories(${GTKMM3_INCLUDE_DIRS} ${WEBKIT_INCLUDE_DIRS})
 
 add_executable(WhatsApp src/main.cpp src/MainWindow.cpp src/WebView.cpp src/Settings.cpp)
 target_link_libraries(WhatsApp ${GTKMM3_LIBRARIES} ${WEBKIT_LIBRARIES})
+install(TARGETS WhatsApp DESTINATION bin)


### PR DESCRIPTION
This way, packagers can use `make install` rather than having to figure out what to install and where to install it.

This can be extended to installing the UI files if issue #14 ends up going in that direction.