### PR TITLE
Add compile-time setting for the path to the UI resources.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,23 @@ project(WhatsApp)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Resource options.
+option(INSTALL_RESOURCES "Install the resources." OFF)
+set(RESOURCE_PATH "share/whatsapp-for-linux" CACHE PATH "Path (relative to CMAKE_INSTALL_PREFIX) the resources will be installed to.")
+
+# Figure out the resource path.
+if(INSTALL_RESOURCES)
+    set(RESOURCE_DIR ${CMAKE_INSTALL_PREFIX}/${RESOURCE_PATH})
+else()
+    set(RESOURCE_DIR)
+endif()
+
+# Process config.hpp.in.
+configure_file(src/Config.hpp.in Config.hpp)
+
+# So that the source code can #include config.hpp
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
 FIND_PACKAGE(PkgConfig REQUIRED)
 PKG_CHECK_MODULES(GTKMM3 gtkmm-3.0 REQUIRED)
 PKG_CHECK_MODULES(WEBKIT webkit2gtk-4.0 REQUIRED)
@@ -11,4 +28,9 @@ include_directories(${GTKMM3_INCLUDE_DIRS} ${WEBKIT_INCLUDE_DIRS})
 
 add_executable(WhatsApp src/main.cpp src/MainWindow.cpp src/WebView.cpp src/Settings.cpp)
 target_link_libraries(WhatsApp ${GTKMM3_LIBRARIES} ${WEBKIT_LIBRARIES})
+
+# Installation.
 install(TARGETS WhatsApp DESTINATION bin)
+if(INSTALL_RESOURCES)
+    install(DIRECTORY ui DESTINATION ${RESOURCE_PATH})
+endif()

--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Build & Run
 
+For development:
+
 1. Create a debug build directory. `mkdir -p build/debug`
 2. Build. `cmake -DCMAKE_BUILD_TYPE=Debug --build build/debug`
 3. Create symbolic links to ui files in build folder. `ln -s ui/ build/debug/`
 4. Run. `./build/debug/WhatsApp`
+
+For full installation, add `-DINSTALL_RESOURCES=on` to the CMake options, and
+use `cmake --install build/debug` or `make install -C build/debug` after
+building (you'll probably need administrator privileges for the installation).

--- a/src/Config.hpp.in
+++ b/src/Config.hpp.in
@@ -1,0 +1,13 @@
+#pragma once
+
+/** This file is automatically processed by CMake.
+ *  Make any changes to src/config.hpp.in, not config.hpp
+ */
+
+#include <filesystem>
+
+#cmakedefine INSTALL_RESOURCES
+
+auto const resourceDir(std::filesystem::path("${RESOURCE_DIR}"));
+auto const uiDir(resourceDir / "ui");
+auto const iconDir(uiDir / "icon");

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2,6 +2,7 @@
 #include <gtkmm/grid.h>
 #include <gtkmm/menuitem.h>
 #include <gtkmm/aboutdialog.h>
+#include "Config.hpp"
 
 
 MainWindow::MainWindow(BaseObjectType* cobject, Glib::RefPtr<Gtk::Builder> const& refBuilder)
@@ -10,12 +11,12 @@ MainWindow::MainWindow(BaseObjectType* cobject, Glib::RefPtr<Gtk::Builder> const
 {
     set_default_size(1280, 720);
 
-    auto const appIcon16x16   = Gdk::Pixbuf::create_from_file("ui/icon/16x16.ico");
-    auto const appIcon32x32   = Gdk::Pixbuf::create_from_file("ui/icon/32x32.ico");
-    auto const appIcon48x48   = Gdk::Pixbuf::create_from_file("ui/icon/48x48.ico");
-    auto const appIcon64x64   = Gdk::Pixbuf::create_from_file("ui/icon/64x64.ico");
-    auto const appIcon128x128 = Gdk::Pixbuf::create_from_file("ui/icon/128x128.ico");
-    auto const appIcon256x256 = Gdk::Pixbuf::create_from_file("ui/icon/256x256.ico");
+    auto const appIcon16x16   = Gdk::Pixbuf::create_from_file(iconDir / "16x16.ico");
+    auto const appIcon32x32   = Gdk::Pixbuf::create_from_file(iconDir / "32x32.ico");
+    auto const appIcon48x48   = Gdk::Pixbuf::create_from_file(iconDir / "48x48.ico");
+    auto const appIcon64x64   = Gdk::Pixbuf::create_from_file(iconDir / "64x64.ico");
+    auto const appIcon128x128 = Gdk::Pixbuf::create_from_file(iconDir / "128x128.ico");
+    auto const appIcon256x256 = Gdk::Pixbuf::create_from_file(iconDir / "256x256.ico");
     set_icon_list({appIcon16x16, appIcon32x32, appIcon48x48, appIcon64x64, appIcon128x128, appIcon256x256});
 
     Gtk::Grid* mainGrid = nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,12 @@
 #include "MainWindow.hpp"
+#include "Config.hpp"
 
 
 int main(int argc, char** argv)
 {
     auto const app = Gtk::Application::create(argc, argv, {});
 
-    auto const refBuilder = Gtk::Builder::create_from_file("ui/MainWindow.ui");
+    auto const refBuilder = Gtk::Builder::create_from_file(uiDir / "MainWindow.ui");
 
     MainWindow* mainWindow = nullptr;
     refBuilder->get_widget_derived("main_window", mainWindow);


### PR DESCRIPTION
* Add CMake options to enable installation of the resources and their path
  (relative to the installation prefix).
* Use CMake's configure_file() to create a config.hpp from a template making
  these settings available to the code.
* Make the UI and icons load relative to the paths in config.hpp.

The default behaviour is as before; -DINSTALL_RESOURCES=on is required
to change the behaviour for a full install.

Closes GitHub issue #14.