### PR TITLE
Change of titlebar / menubar to GNOME HeaderBar

### DIFF
--- a/resource/ui/MainWindow.ui
+++ b/resource/ui/MainWindow.ui
@@ -2,11 +2,70 @@
 <!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkMenu" id="header_menu">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkMenuItem" id="fullscreen_menu_item">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Fullscreen</property>
+        <property name="use_underline">True</property>
+        <accelerator key="F11" signal="activate"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="about_menu_item">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">About</property>
+        <property name="use_underline">True</property>
+        <accelerator key="F1" signal="activate"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="quit_menu_item">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Quit</property>
+        <property name="use_underline">True</property>
+      </object>
+    </child>
+  </object>
   <object class="GtkWindow" id="main_window">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">WhatsApp</property>
     <child type="titlebar">
-      <placeholder/>
+      <object class="GtkHeaderBar" id="header_bar">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="title" translatable="yes">WhatsApp for Linux</property>
+        <property name="has_subtitle">False</property>
+        <property name="show_close_button">True</property>
+        <child>
+          <object class="GtkButton" id="refresh_button">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <accelerator key="F5" signal="clicked" />
+          </object>
+        </child>
+        <child>
+          <object class="GtkMenuButton" id="header_menu_button">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="focus_on_click">False</property>
+            <property name="receives_default">True</property>
+            <property name="popup">header_menu</property>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="pack_type">end</property>
+          </packing>
+        </child>
+      </object>
     </child>
     <child>
       <object class="GtkGrid" id="main_grid">
@@ -14,97 +73,7 @@
         <property name="can_focus">False</property>
         <property name="column_homogeneous">True</property>
         <child>
-          <object class="GtkMenuBar" id="menubar">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <child>
-              <object class="GtkMenuItem">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">_Application</property>
-                <property name="use_underline">True</property>
-                <child type="submenu">
-                  <object class="GtkMenu">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkMenuItem" id="refresh_menu_item">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label">Refresh</property>
-                        <property name="use_underline">True</property>
-                        <accelerator key="F5" signal="activate"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSeparatorMenuItem">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkMenuItem" id="quit_menu_item">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label">Quit</property>
-                        <property name="use_underline">True</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkMenuItem">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">_View</property>
-                <property name="use_underline">True</property>
-                <child type="submenu">
-                  <object class="GtkMenu">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkMenuItem" id="fullscreen_menu_item">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label">Fullscreen</property>
-                        <property name="use_underline">True</property>
-                        <accelerator key="F11" signal="activate"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkMenuItem">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">_Help</property>
-                <property name="use_underline">True</property>
-                <child type="submenu">
-                  <object class="GtkMenu">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkMenuItem" id="about_menu_item">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label">About</property>
-                        <property name="use_underline">True</property>
-                        <accelerator key="F1" signal="activate"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">0</property>
-          </packing>
+          <placeholder/>
         </child>
       </object>
     </child>

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -22,9 +22,16 @@ MainWindow::MainWindow(BaseObjectType* cobject, Glib::RefPtr<Gtk::Builder> const
     mainGrid->attach(m_webView, 0, 1, 1, 1);
     m_webView.set_vexpand();
 
-    Gtk::MenuItem* refreshMenuItem = nullptr;
-    refBuilder->get_widget("refresh_menu_item", refreshMenuItem);
-    refreshMenuItem->signal_activate().connect(sigc::mem_fun(this, &MainWindow::onRefresh));
+    Gtk::Button* refreshButton = nullptr;
+    refBuilder->get_widget("refresh_button", refreshButton);
+    refreshButton->set_image_from_icon_name("view-refresh-symbolic", Gtk::BuiltinIconSize::ICON_SIZE_BUTTON);
+    refreshButton->set_always_show_image(true);
+    refreshButton->signal_clicked().connect(sigc::mem_fun(this, &MainWindow::onRefresh));
+
+    Gtk::Button* headerMenuButton = nullptr;
+    refBuilder->get_widget("header_menu_button", headerMenuButton);
+    headerMenuButton->set_image_from_icon_name("start-here", Gtk::BuiltinIconSize::ICON_SIZE_BUTTON);
+    headerMenuButton->set_always_show_image(true);
 
     Gtk::MenuItem* quitMenuItem = nullptr;
     refBuilder->get_widget("quit_menu_item", quitMenuItem);


### PR DESCRIPTION
Small change to replace the default titlebar / menubar on the application window with the new headerbar, used in GNOME.

![w4l_hbar](https://user-images.githubusercontent.com/7938006/93132303-c600c080-f6ab-11ea-9358-cf0c8531daf9.png)
