### PR TITLE
Auto tray start

### DIFF
--- a/resource/ui/MainWindow.ui
+++ b/resource/ui/MainWindow.ui
@@ -131,16 +131,16 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButtonBox" id="start_at_tray_buttonbox">
+          <object class="GtkButtonBox" id="start_in_tray_buttonbox">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="spacing">5</property>
             <property name="layout-style">center</property>
             <child>
-              <object class="GtkLabel" id="start_at_tray_label">
+              <object class="GtkLabel" id="start_in_tray_label">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Start At Tray</property>
+                <property name="label" translatable="yes">Start In Tray</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -150,14 +150,14 @@
               </packing>
             </child>
             <child>
-              <object class="GtkSwitch" id="start_at_tray_switch">
+              <object class="GtkSwitch" id="start_in_tray_switch">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">3</property>
+                <property name="position">2</property>
                 <property name="non-homogeneous">True</property>
               </packing>
             </child>

--- a/resource/ui/MainWindow.ui
+++ b/resource/ui/MainWindow.ui
@@ -131,6 +131,44 @@
           </packing>
         </child>
         <child>
+          <object class="GtkButtonBox" id="start_at_tray_buttonbox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="spacing">5</property>
+            <property name="layout-style">center</property>
+            <child>
+              <object class="GtkLabel" id="start_at_tray_label">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Start At Tray</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+                <property name="non-homogeneous">True</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="start_at_tray_switch">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+                <property name="non-homogeneous">True</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkButton" id="fullscreen_button">
             <property name="label" translatable="yes">Fullscreen    F11</property>
             <property name="visible">True</property>
@@ -141,7 +179,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">3</property>
+            <property name="position">4</property>
           </packing>
         </child>
         <child>
@@ -152,7 +190,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">4</property>
+            <property name="position">5</property>
           </packing>
         </child>
         <child>
@@ -166,7 +204,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">5</property>
+            <property name="position">6</property>
           </packing>
         </child>
         <child>
@@ -180,7 +218,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">6</property>
+            <property name="position">7</property>
           </packing>
         </child>
       </object>

--- a/resource/ui/MainWindow.ui
+++ b/resource/ui/MainWindow.ui
@@ -157,7 +157,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">3</property>
                 <property name="non-homogeneous">True</property>
               </packing>
             </child>

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -6,7 +6,6 @@
 #include <gtkmm/button.h>
 #include <gtkmm/switch.h>
 #include <gtkmm/aboutdialog.h>
-#include <iostream>
 
 namespace
 {
@@ -78,7 +77,7 @@ MainWindow::MainWindow(BaseObjectType* cobject, Glib::RefPtr<Gtk::Builder> const
 
     show_all();
 
-    m_trayIcon.setVisible(Settings::instance().closeToTray());
+    m_trayIcon.setVisible(Settings::instance().closeToTray() || Settings::instance().startAtTray());
     startAtTraySwitch->set_state(Settings::instance().startAtTray());
     closeToTraySwitch->set_state(m_trayIcon.visible());
 
@@ -132,10 +131,6 @@ bool MainWindow::on_delete_event(GdkEventAny* any_event)
     }
     else
     {
-        if(Settings::instance().startAtTray())
-        {
-            Settings::instance().setCloseToTray(true);
-        }
         Application::instance().endKeepAlive();
     }
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -6,6 +6,7 @@
 #include <gtkmm/button.h>
 #include <gtkmm/switch.h>
 #include <gtkmm/aboutdialog.h>
+#include <iostream>
 
 namespace
 {
@@ -43,6 +44,10 @@ MainWindow::MainWindow(BaseObjectType* cobject, Glib::RefPtr<Gtk::Builder> const
     refBuilder->get_widget("close_to_tray_switch", closeToTraySwitch);
     closeToTraySwitch->signal_state_set().connect(sigc::mem_fun(this, &MainWindow::onCloseToTray), false);
 
+    Gtk::Switch* startAtTraySwitch = nullptr;
+    refBuilder->get_widget("start_at_tray_switch", startAtTraySwitch);
+    startAtTraySwitch->signal_state_set().connect(sigc::mem_fun(this, &MainWindow::onStartAtTray), false);
+
     Gtk::Button* fullscreenButton = nullptr;
     refBuilder->get_widget("fullscreen_button", fullscreenButton);
     fullscreenButton->signal_clicked().connect(sigc::mem_fun(this, &MainWindow::onFullscreen));
@@ -74,6 +79,7 @@ MainWindow::MainWindow(BaseObjectType* cobject, Glib::RefPtr<Gtk::Builder> const
     show_all();
 
     m_trayIcon.setVisible(Settings::instance().closeToTray());
+    startAtTraySwitch->set_state(Settings::instance().startAtTray());
     closeToTraySwitch->set_state(m_trayIcon.visible());
 
     m_headerBar->set_visible(Settings::instance().headerBar());
@@ -126,6 +132,10 @@ bool MainWindow::on_delete_event(GdkEventAny* any_event)
     }
     else
     {
+        if(Settings::instance().startAtTray())
+        {
+            Settings::instance().setCloseToTray(true);
+        }
         Application::instance().endKeepAlive();
     }
 
@@ -165,6 +175,12 @@ bool MainWindow::onCloseToTray(bool visible)
     m_trayIcon.setVisible(visible);
     Settings::instance().setCloseToTray(visible);
 
+    return false;
+}
+
+bool MainWindow::onStartAtTray(bool visible)
+{
+    Settings::instance().setStartAtTray(visible);
     return false;
 }
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -43,9 +43,9 @@ MainWindow::MainWindow(BaseObjectType* cobject, Glib::RefPtr<Gtk::Builder> const
     refBuilder->get_widget("close_to_tray_switch", closeToTraySwitch);
     closeToTraySwitch->signal_state_set().connect(sigc::mem_fun(this, &MainWindow::onCloseToTray), false);
 
-    Gtk::Switch* startAtTraySwitch = nullptr;
-    refBuilder->get_widget("start_at_tray_switch", startAtTraySwitch);
-    startAtTraySwitch->signal_state_set().connect(sigc::mem_fun(this, &MainWindow::onStartAtTray), false);
+    Gtk::Switch* startInTraySwitch = nullptr;
+    refBuilder->get_widget("start_in_tray_switch", startInTraySwitch);
+    startInTraySwitch->signal_state_set().connect(sigc::mem_fun(this, &MainWindow::onStartInTray), false);
 
     Gtk::Button* fullscreenButton = nullptr;
     refBuilder->get_widget("fullscreen_button", fullscreenButton);
@@ -77,9 +77,9 @@ MainWindow::MainWindow(BaseObjectType* cobject, Glib::RefPtr<Gtk::Builder> const
 
     show_all();
 
-    m_trayIcon.setVisible(Settings::instance().closeToTray() || Settings::instance().startAtTray());
-    startAtTraySwitch->set_state(Settings::instance().startAtTray());
-    closeToTraySwitch->set_state(m_trayIcon.visible());
+    m_trayIcon.setVisible(Settings::instance().closeToTray() || Settings::instance().startInTray());
+    startInTraySwitch->set_state(Settings::instance().startInTray());
+    closeToTraySwitch->set_state(Settings::instance().closeToTray());
 
     m_headerBar->set_visible(Settings::instance().headerBar());
 }
@@ -173,9 +173,9 @@ bool MainWindow::onCloseToTray(bool visible)
     return false;
 }
 
-bool MainWindow::onStartAtTray(bool visible)
+bool MainWindow::onStartInTray(bool visible)
 {
-    Settings::instance().setStartAtTray(visible);
+    Settings::instance().setStartInTray(visible);
     return false;
 }
 

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -23,6 +23,7 @@ class MainWindow
         void onShow();
         void onQuit(bool immediate);
         bool onCloseToTray(bool state);
+        bool onStartAtTray(bool visible);
         void onFullscreen();
         void onAbout();
         void onZoomIn(Gtk::Label* zoomLevelLabel);

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -23,7 +23,7 @@ class MainWindow
         void onShow();
         void onQuit(bool immediate);
         bool onCloseToTray(bool state);
-        bool onStartAtTray(bool visible);
+        bool onStartInTray(bool visible);
         void onFullscreen();
         void onAbout();
         void onZoomIn(Gtk::Label* zoomLevelLabel);

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -149,4 +149,6 @@ bool Settings::startAtTray() const
     {
         std::cerr << "Settings: " << error.what() << std::endl;
     }
+
+    return enable;
 }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -132,3 +132,21 @@ bool Settings::headerBar() const
 
     return enable;
 }
+
+void Settings::setStartAtTray(bool enable)
+{
+    m_keyFile.set_boolean(GROUP_GENERAL, "start_at_tray", enable);
+}
+
+bool Settings::startAtTray() const
+{
+    auto enable = false;
+    try
+    {
+        enable = m_keyFile.get_boolean(GROUP_GENERAL, "start_at_tray");
+    }
+    catch (Glib::KeyFileError const& error)
+    {
+        std::cerr << "Settings: " << error.what() << std::endl;
+    }
+}

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -133,17 +133,17 @@ bool Settings::headerBar() const
     return enable;
 }
 
-void Settings::setStartAtTray(bool enable)
+void Settings::setStartInTray(bool enable)
 {
-    m_keyFile.set_boolean(GROUP_GENERAL, "start_at_tray", enable);
+    m_keyFile.set_boolean(GROUP_GENERAL, "start_in_tray", enable);
 }
 
-bool Settings::startAtTray() const
+bool Settings::startInTray() const
 {
     auto enable = false;
     try
     {
-        enable = m_keyFile.get_boolean(GROUP_GENERAL, "start_at_tray");
+        enable = m_keyFile.get_boolean(GROUP_GENERAL, "start_in_tray");
     }
     catch (Glib::KeyFileError const& error)
     {

--- a/src/Settings.hpp
+++ b/src/Settings.hpp
@@ -20,6 +20,8 @@ class Settings
         double zoomLevel() const;
         void   setHeaderBar(bool enable);
         bool   headerBar() const;
+        void   setStartAtTray(bool enable);
+        bool   startAtTray() const;
 
     private:
         Settings();

--- a/src/Settings.hpp
+++ b/src/Settings.hpp
@@ -20,8 +20,8 @@ class Settings
         double zoomLevel() const;
         void   setHeaderBar(bool enable);
         bool   headerBar() const;
-        void   setStartAtTray(bool enable);
-        bool   startAtTray() const;
+        void   setStartInTray(bool enable);
+        bool   startInTray() const;
 
     private:
         Settings();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include "Application.hpp"
 #include "MainWindow.hpp"
+#include "Settings.hpp"
 
 int main(int argc, char** argv)
 {
@@ -21,5 +22,17 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    return app.run(*mainWindow);
+    int retCode = 0;
+    if(Settings::instance().closeToTray())
+    {
+        mainWindow->hide();
+        Application::instance().keepAlive();
+        retCode = app.run();
+    }
+    else
+    {
+        retCode = app.run(*mainWindow);
+    }
+
+    return retCode;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,7 @@ int main(int argc, char** argv)
     }
 
     int retCode = 0;
-    if(Settings::instance().closeToTray())
+    if(Settings::instance().startAtTray())
     {
         mainWindow->hide();
         Application::instance().keepAlive();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,8 +22,9 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    int retCode = 0;
-    if(Settings::instance().startAtTray())
+    auto retCode = 0;
+    
+    if(Settings::instance().startInTray())
     {
         mainWindow->hide();
         Application::instance().keepAlive();


### PR DESCRIPTION
Fixes #83 

**Proposed Changes**
 -New switch for start on tray
 -If switch enabled, application starts on closed to tray
 
I did not implement autostart on system startup. In my opinion, autostart on system startup and start on tray are different.It is better to have new switch or option for autostart on system startup.
