### PR TITLE
Change menu icon and buttons to match GNOME style

### DIFF
--- a/resource/gresource.xml
+++ b/resource/gresource.xml
@@ -2,6 +2,7 @@
 <gresources>
   <gresource prefix="main">
     <file>ui/MainWindow.ui</file>
+    <file>ui/ShortcutsWindow.ui</file>
     <file>image/icons/hicolor/16x16/apps/whatsapp-for-linux.png</file>
     <file>image/icons/hicolor/32x32/apps/whatsapp-for-linux.png</file>
     <file>image/icons/hicolor/64x64/apps/whatsapp-for-linux.png</file>

--- a/resource/ui/MainWindow.ui
+++ b/resource/ui/MainWindow.ui
@@ -96,35 +96,13 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButtonBox" id="close_to_tray_buttonbox">
+          <object class="GtkModelButton" id="close_to_tray_button">
+            <property name="text" translatable="yes">Close To Tray</property>
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="spacing">4</property>
-            <child>
-              <object class="GtkLabel" id="close_to_tray_label">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Close To Tray</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-                <property name="non-homogeneous">True</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="close_to_tray_switch">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-                <property name="non-homogeneous">True</property>
-              </packing>
-            </child>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="relief">none</property>
+            <property name="role">check</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -133,35 +111,13 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButtonBox" id="start_in_tray_buttonbox">
+          <object class="GtkModelButton" id="start_in_tray_button">
+            <property name="text" translatable="yes">Start In Tray</property>
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="spacing">4</property>
-            <child>
-              <object class="GtkLabel" id="start_in_tray_label">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Start In Tray</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-                <property name="non-homogeneous">True</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="start_in_tray_switch">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-                <property name="non-homogeneous">True</property>
-              </packing>
-            </child>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="relief">none</property>
+            <property name="role">check</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -170,35 +126,13 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButtonBox" id="autostart_buttonbox">
+          <object class="GtkModelButton" id="autostart_button">
+            <property name="text" translatable="yes">Autostart</property>
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="spacing">4</property>
-            <child>
-              <object class="GtkLabel" id="autostart_label">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Autostart</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-                <property name="non-homogeneous">True</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="autostart_switch">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-                <property name="non-homogeneous">True</property>
-              </packing>
-            </child>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="relief">none</property>
+            <property name="role">check</property>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/resource/ui/MainWindow.ui
+++ b/resource/ui/MainWindow.ui
@@ -142,7 +142,7 @@
         </child>
         <child>
           <object class="GtkModelButton" id="fullscreen_button">
-            <property name="text" translatable="yes">Fullscreen    F11</property>
+            <property name="text" translatable="yes">_Fullscreen</property>
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">True</property>
@@ -166,12 +166,11 @@
           </packing>
         </child>
         <child>
-          <object class="GtkModelButton" id="about_button">
-            <property name="text" translatable="yes">About</property>
+          <object class="GtkModelButton" id="shortcuts_button">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">True</property>
-            <property name="relief">none</property>
+            <property name="text" translatable="yes">_Keyboard Shortcuts</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -180,8 +179,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkModelButton" id="quit_button">
-            <property name="text" translatable="yes">Quit    Ctrl+Q</property>
+          <object class="GtkModelButton" id="about_button">
+            <property name="text" translatable="yes">_About</property>
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">True</property>
@@ -191,6 +190,20 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">8</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="quit_button">
+            <property name="text" translatable="yes">_Quit</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="relief">none</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">9</property>
           </packing>
         </child>
       </object>

--- a/resource/ui/MainWindow.ui
+++ b/resource/ui/MainWindow.ui
@@ -238,12 +238,12 @@
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">True</property>
-            <property name="tooltip-text" translatable="yes">Refresh  F5</property>
+            <property name="tooltip-text" translatable="yes">Refresh</property>
             <child>
               <object class="GtkImage" id="refresh_image">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="icon-name">view-refresh</property>
+                <property name="icon-name">view-refresh-symbolic</property>
               </object>
             </child>
             <accelerator key="F5" signal="clicked"/>

--- a/resource/ui/MainWindow.ui
+++ b/resource/ui/MainWindow.ui
@@ -25,6 +25,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
+                <property name="relief">none</property>
                 <property name="always-show-image">True</property>
                 <child>
                   <object class="GtkImage">
@@ -59,6 +60,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
+                <property name="relief">none</property>
                 <property name="always-show-image">True</property>
                 <child>
                   <object class="GtkImage">
@@ -205,8 +207,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButton" id="fullscreen_button">
-            <property name="label" translatable="yes">Fullscreen    F11</property>
+          <object class="GtkModelButton" id="fullscreen_button">
+            <property name="text" translatable="yes">Fullscreen    F11</property>
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">True</property>
@@ -230,8 +232,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButton" id="about_button">
-            <property name="label" translatable="yes">About</property>
+          <object class="GtkModelButton" id="about_button">
+            <property name="text" translatable="yes">About</property>
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">True</property>
@@ -244,8 +246,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButton" id="quit_button">
-            <property name="label" translatable="yes">Quit    Ctrl+Q</property>
+          <object class="GtkModelButton" id="quit_button">
+            <property name="text" translatable="yes">Quit    Ctrl+Q</property>
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">True</property>
@@ -311,7 +313,7 @@
               <object class="GtkImage" id="header_menu_image">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="icon-name">start-here</property>
+                <property name="icon-name">open-menu-symbolic</property>
               </object>
             </child>
           </object>

--- a/resource/ui/ShortcutsWindow.ui
+++ b/resource/ui/ShortcutsWindow.ui
@@ -28,7 +28,7 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">1</property>
-                <property name="accelerator">&lt;ctrl&gt;H</property>
+                <property name="accelerator">&lt;alt&gt;H</property>
                 <property name="title" translatable="yes">Show/hide Header bar</property>
               </object>
             </child>

--- a/resource/ui/ShortcutsWindow.ui
+++ b/resource/ui/ShortcutsWindow.ui
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <object class="GtkShortcutsWindow" id="shortcuts_window">
+    <property name="modal">1</property>
+    <property name="title" translatable="yes">Shortcuts</property>
+    <child>
+      <object class="GtkShortcutsSection">
+        <property name="section-name">shortcuts</property>
+        <property name="visible">1</property>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="title" translatable="yes">General</property>
+            <property name="visible">1</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">1</property>
+                <property name="accelerator">F11</property>
+                <property name="title" translatable="yes">Enter/Exit Fullscreen</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">1</property>
+                <property name="accelerator">&lt;ctrl&gt;H</property>
+                <property name="title" translatable="yes">Show/hide Header bar</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">1</property>
+                <property name="accelerator">&lt;ctrl&gt;question</property>
+                <property name="title" translatable="yes">Keyboard Shortcuts</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">1</property>
+                <property name="accelerator">&lt;ctrl&gt;Q</property>
+                <property name="title" translatable="yes">Quit</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/resource/ui/ShortcutsWindow.ui
+++ b/resource/ui/ShortcutsWindow.ui
@@ -14,6 +14,13 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">1</property>
+                <property name="accelerator">F5</property>
+                <property name="title" translatable="yes">Refresh Page</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">1</property>
                 <property name="accelerator">F11</property>
                 <property name="title" translatable="yes">Enter/Exit Fullscreen</property>
               </object>

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -3,6 +3,7 @@
 #include <gtkmm/button.h>
 #include <gtkmm/modelbutton.h>
 #include <gtkmm/aboutdialog.h>
+#include <gtkmm/shortcutswindow.h>
 #include "Application.hpp"
 #include "Version.hpp"
 #include "Settings.hpp"
@@ -12,6 +13,7 @@ MainWindow::MainWindow(BaseObjectType* cobject, Glib::RefPtr<Gtk::Builder> const
     , m_trayIcon{}
     , m_webView{}
     , m_fullscreen{false}
+    , m_shortcutsWindow{nullptr}
 {
     auto const appIcon16x16   = Gdk::Pixbuf::create_from_resource("/main/image/icons/hicolor/16x16/apps/whatsapp-for-linux.png");
     auto const appIcon32x32   = Gdk::Pixbuf::create_from_resource("/main/image/icons/hicolor/32x32/apps/whatsapp-for-linux.png");
@@ -57,6 +59,10 @@ MainWindow::MainWindow(BaseObjectType* cobject, Glib::RefPtr<Gtk::Builder> const
     Gtk::Button* zoomOutButton = nullptr;
     refBuilder->get_widget("zoom_out_button", zoomOutButton);
     zoomOutButton->signal_clicked().connect(sigc::bind(sigc::mem_fun(this, &MainWindow::onZoomOut), zoomLevelLabel));
+
+    Gtk::Button* shortcutsButton = nullptr;
+    refBuilder->get_widget("shortcuts_button", shortcutsButton);
+    shortcutsButton->signal_clicked().connect(sigc::mem_fun(this, &MainWindow::onShortcuts));
 
     Gtk::Button* aboutButton = nullptr;
     refBuilder->get_widget("about_button", aboutButton);
@@ -106,6 +112,14 @@ bool MainWindow::on_key_press_event(GdkEventKey* keyEvent)
             if (keyEvent->state & GDK_CONTROL_MASK)
             {
                 onQuit();
+                return true;
+            }
+            break;
+
+        case GDK_KEY_question:
+            if (keyEvent->state & GDK_CONTROL_MASK)
+            {
+                onShortcuts();
                 return true;
             }
             break;
@@ -223,4 +237,17 @@ void MainWindow::onAbout()
     aboutDialog.set_license_type(Gtk::LICENSE_GPL_3_0);
 
     aboutDialog.run();
+}
+
+void MainWindow::onShortcuts()
+{
+    if (!m_shortcutsWindow)
+    {
+        auto const refBuilder = Gtk::Builder::create_from_resource("/main/ui/ShortcutsWindow.ui");
+
+        refBuilder->get_widget("shortcuts_window", m_shortcutsWindow);
+    }
+
+    m_shortcutsWindow->set_transient_for(*this);
+    m_shortcutsWindow->show_all();
 }

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -28,12 +28,14 @@ class MainWindow
         void onAutostart(Gtk::ModelButton* autostartButton);
         void onFullscreen();
         void onAbout();
+        void onShortcuts();
         void onZoomIn(Gtk::Label* zoomLevelLabel);
         void onZoomOut(Gtk::Label* zoomLevelLabel);
 
     private:
-        TrayIcon        m_trayIcon;
-        WebView         m_webView;
-        Gtk::HeaderBar* m_headerBar;
-        bool            m_fullscreen;
+        TrayIcon              m_trayIcon;
+        WebView               m_webView;
+        Gtk::HeaderBar*       m_headerBar;
+        Gtk::ShortcutsWindow* m_shortcutsWindow;
+        bool                  m_fullscreen;
 };

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -4,7 +4,7 @@
 #include <gtkmm/builder.h>
 #include <gtkmm/headerbar.h>
 #include <gtkmm/label.h>
-#include <gtkmm/switch.h>
+#include <gtkmm/modelbutton.h>
 #include "TrayIcon.hpp"
 #include "WebView.hpp"
 
@@ -23,9 +23,9 @@ class MainWindow
         void onRefresh();
         void onShow();
         void onQuit();
-        bool onCloseToTray(bool visible, Gtk::Switch* startInTraySwitch);
-        bool onStartInTray(bool visible);
-        bool onAutostart(bool autostart);
+        void onCloseToTray(Gtk::ModelButton* closeToTrayButton, Gtk::ModelButton* startInTrayButton);
+        void onStartInTray(Gtk::ModelButton* startInTrayButton);
+        void onAutostart(Gtk::ModelButton* autostartButton);
         void onFullscreen();
         void onAbout();
         void onZoomIn(Gtk::Label* zoomLevelLabel);


### PR DESCRIPTION
The goal of this PR is to make the GTK features look and behave more like other GTK apps, specially those with a header bar.

**Proposed Changes**
 - Change header bar menu icon from `start-here` to `open-menu-symbolic`
 - Use flat buttons for
 - Use checkboxes instead of switches in the menu
 - Remove keyboard shortcut hints from buttons and tooltips and show them in a window dedicated to shortcuts.

![image](https://user-images.githubusercontent.com/1831465/128938306-b41f275f-446b-4819-9376-0426a1a8d7ba.png)

![image](https://user-images.githubusercontent.com/1831465/128938345-f04fe635-e40b-45e7-a453-0b772bcd8bc5.png)