### PR TITLE
Raise existing window when "Open" tray option is clicked

### DIFF
--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -219,6 +219,10 @@ namespace wfl::ui
             Application::getInstance().add_window(*this);
             show();
         }
+        else
+        {
+            present();
+        }
     }
 
     void MainWindow::onQuit()

--- a/src/ui/TrayIcon.cpp
+++ b/src/ui/TrayIcon.cpp
@@ -40,7 +40,7 @@ namespace wfl::ui
         app_indicator_set_icon_full(m_appIndicator, trayIconName, "Whatsapp for Linux Tray");
         app_indicator_set_attention_icon_full(m_appIndicator, attentionIconName, "Whatsapp for Linux Tray Attention");
 
-        auto const openMenuItem = Gtk::manage(new Gtk::MenuItem{"Open"});
+        auto const openMenuItem = Gtk::manage(new Gtk::MenuItem{"Show"});
         auto const aboutMenuItem = Gtk::manage(new Gtk::MenuItem{"About"});
         auto const quitMenuItem = Gtk::manage(new Gtk::MenuItem{"Quit"});
         m_popupMenu.append(*openMenuItem);


### PR DESCRIPTION
**Proposed Changes**
- On clicking the "Open" button in the tray icon's menu, bring the WhatsApp window to the foreground if it is already opened.
- Change the "Open" label to "Show", as it is possibly more appropriate, considering the new behaviour