### PR TITLE
Fix #80

### DIFF
--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -83,6 +83,7 @@ namespace wfl::ui
 
         m_webView.signalLoadStatus().connect(sigc::mem_fun(*this, &MainWindow::onLoadStatusChanged));
         m_webView.signalNotification().connect(sigc::mem_fun(m_trayIcon, &TrayIcon::setAttention));
+        m_webView.signalNotificationClicked().connect(sigc::mem_fun(*this, &MainWindow::onNotificationClicked));
         m_trayIcon.signalShow().connect(sigc::mem_fun(*this, &MainWindow::onShow));
         m_trayIcon.signalAbout().connect(sigc::mem_fun(*this, &MainWindow::onAbout));
         m_trayIcon.signalQuit().connect(sigc::mem_fun(*this, &MainWindow::onQuit));
@@ -308,5 +309,13 @@ namespace wfl::ui
 
         aboutDialog.set_transient_for(*this);
         aboutDialog.run();
+    }
+    void MainWindow::onNotificationClicked()
+    {
+        if (!is_visible())
+        {
+            Application::getInstance().add_window(*this);
+            show();
+        }
     }
 }

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -83,7 +83,7 @@ namespace wfl::ui
 
         m_webView.signalLoadStatus().connect(sigc::mem_fun(*this, &MainWindow::onLoadStatusChanged));
         m_webView.signalNotification().connect(sigc::mem_fun(m_trayIcon, &TrayIcon::setAttention));
-        m_webView.signalNotificationClicked().connect(sigc::mem_fun(*this, &MainWindow::onNotificationClicked));
+        m_webView.signalNotificationClicked().connect(sigc::mem_fun(*this, &MainWindow::onShow));
         m_trayIcon.signalShow().connect(sigc::mem_fun(*this, &MainWindow::onShow));
         m_trayIcon.signalAbout().connect(sigc::mem_fun(*this, &MainWindow::onAbout));
         m_trayIcon.signalQuit().connect(sigc::mem_fun(*this, &MainWindow::onQuit));
@@ -218,12 +218,9 @@ namespace wfl::ui
         if (!is_visible())
         {
             Application::getInstance().add_window(*this);
-            show();
         }
-        else
-        {
-            present();
-        }
+
+        present();
     }
 
     void MainWindow::onQuit()
@@ -309,13 +306,5 @@ namespace wfl::ui
 
         aboutDialog.set_transient_for(*this);
         aboutDialog.run();
-    }
-    void MainWindow::onNotificationClicked()
-    {
-        if (!is_visible())
-        {
-            Application::getInstance().add_window(*this);
-            show();
-        }
     }
 }

--- a/src/ui/MainWindow.hpp
+++ b/src/ui/MainWindow.hpp
@@ -32,6 +32,7 @@ namespace wfl::ui
             void onPhoneNumberDialogResponse(int responseId);
             void onShow();
             void onQuit();
+            void onNotificationClicked();
             void onCloseToTray(Gtk::ModelButton* closeToTrayButton, Gtk::ModelButton* startInTrayButton);
             void onStartInTray(Gtk::ModelButton* startInTrayButton);
             void onAutostart(Gtk::ModelButton* autostartButton);

--- a/src/ui/MainWindow.hpp
+++ b/src/ui/MainWindow.hpp
@@ -32,7 +32,6 @@ namespace wfl::ui
             void onPhoneNumberDialogResponse(int responseId);
             void onShow();
             void onQuit();
-            void onNotificationClicked();
             void onCloseToTray(Gtk::ModelButton* closeToTrayButton, Gtk::ModelButton* startInTrayButton);
             void onStartInTray(Gtk::ModelButton* startInTrayButton);
             void onAutostart(Gtk::ModelButton* autostartButton);

--- a/src/ui/WebView.cpp
+++ b/src/ui/WebView.cpp
@@ -126,6 +126,14 @@ namespace wfl::ui
             }
         }
 
+        void notificationClicked(WebKitNotification*, gpointer userData)
+        {
+            if (auto const webView = reinterpret_cast<WebView*>(userData); webView)
+            {
+                webView->signalNotificationClicked().emit();
+            }
+        }
+
         gboolean showNotification(WebKitWebView*, WebKitNotification* notification, gpointer userData)
         {
             auto const webView = reinterpret_cast<WebView*>(userData);
@@ -134,7 +142,7 @@ namespace wfl::ui
                 webView->signalNotification().emit(true);
             }
 
-            g_signal_connect(notification, "clicked", G_CALLBACK(notificationDestroyed), webView);
+            g_signal_connect(notification, "clicked", G_CALLBACK(notificationClicked), webView);
             g_signal_connect(notification, "closed", G_CALLBACK(notificationDestroyed), webView);
 
             return FALSE;
@@ -159,6 +167,7 @@ namespace wfl::ui
         , m_zoomLevel{util::Settings::getInstance().getZoomLevel()}
         , m_signalLoadStatus{}
         , m_signalNotification{}
+        , m_signalNotificationClicked{}
     {
         auto const webContext = webkit_web_view_get_context(*this);
 
@@ -274,6 +283,11 @@ namespace wfl::ui
     sigc::signal<void, bool> WebView::signalNotification() const noexcept
     {
         return m_signalNotification;
+    }
+
+    sigc::signal<void> WebView::signalNotificationClicked() const noexcept
+    {
+        return m_signalNotificationClicked;
     }
 
     void WebView::setLoadStatus(WebKitLoadEvent loadEvent)

--- a/src/ui/WebView.hpp
+++ b/src/ui/WebView.hpp
@@ -33,6 +33,7 @@ namespace wfl::ui
         public:
             sigc::signal<void, WebKitLoadEvent> signalLoadStatus() const noexcept;
             sigc::signal<void, bool>            signalNotification() const noexcept;
+            sigc::signal<void>                  signalNotificationClicked() const noexcept;
 
         private:
             void        setLoadStatus(WebKitLoadEvent loadEvent);
@@ -43,5 +44,6 @@ namespace wfl::ui
             double                              m_zoomLevel;
             sigc::signal<void, WebKitLoadEvent> m_signalLoadStatus;
             sigc::signal<void, bool>            m_signalNotification;
+            sigc::signal<void>                  m_signalNotificationClicked;
     };
 }


### PR DESCRIPTION
Fixes #80 (Raise application window when clicked on notification)

Deals with the situation when the app is minimised to the tray (i.e,
has no windows). The desired behaviour is already displayed well
enough when the app has a window.

Tested on Cinnamon 5.0.6, Debian 12 "Bookworm".