### PR TITLE
ignore clion default cmake directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 
 # Common build directory
 build/
+cmake-build-debug/
 
 # Build artifacts
 src/VERSION


### PR DESCRIPTION
**Proposed Changes**
 - CLion IDE's default CMake directory should be ignored.
