### PR TITLE
WhatsApp Web: Pass [ALT] key as [CMD]

### DIFF
--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -164,6 +164,8 @@ namespace wfl::ui
             }
         }
 
+        if (keyEvent->state & GDK_MOD1_MASK)
+            keyEvent->state += GDK_META_MASK;
 
         return Gtk::ApplicationWindow::on_key_press_event(keyEvent);
     }

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -164,9 +164,6 @@ namespace wfl::ui
             }
         }
 
-        if (keyEvent->state & GDK_MOD1_MASK)
-            keyEvent->state += GDK_META_MASK;
-
         return Gtk::ApplicationWindow::on_key_press_event(keyEvent);
     }
 

--- a/src/ui/WebView.cpp
+++ b/src/ui/WebView.cpp
@@ -338,4 +338,14 @@ namespace wfl::ui
 
         return true;
     }
+
+    bool WebView::on_key_press_event(GdkEventKey* keyEvent)
+    {
+        // This is required for keyboard shortcuts on WhatsApp Web to work. Since it is running
+        // on WebKit, WhatsApp Web listens for Mac's [CMD] key instead of the standard [ALT] key.
+        if (keyEvent->state & GDK_MOD1_MASK)
+            keyEvent->state += GDK_META_MASK;
+
+        return Gtk::Widget::on_key_press_event(keyEvent);
+    }
 }

--- a/src/ui/WebView.hpp
+++ b/src/ui/WebView.hpp
@@ -35,6 +35,9 @@ namespace wfl::ui
             sigc::signal<void, bool>            signalNotification() const noexcept;
             sigc::signal<void>                  signalNotificationClicked() const noexcept;
 
+        protected:
+            bool on_key_press_event(GdkEventKey* keyEvent) override;
+
         private:
             void onLoadStatusChanged(WebKitLoadEvent loadEvent);
             bool onTimeout();


### PR DESCRIPTION
Allow WhatsApp Web to handle the Alt key, so that shortcuts defined
using [ALT]/[CMD] work.

WhatsApp Web defines its own shortcuts. Some of these shortcuts use
the [ALT] key on Windows and Linux, and the [CMD] key on Mac.
However, since Whatsapp-for-Linux runs on WebKit, WhatsApp Web
listens for the [CMD] key instead of the [ALT] key.

This change causes the [CMD] key to be recieved by the webpage when
the [ALT] key is pressed, so that all standard keyboard shortcuts
provided by WhatsApp Web can be used.

Keyboard shortcuts defined by WhatsApp-for-Linux are not affected.
