### PR TITLE
Explicitly specify Canberra dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,4 +24,5 @@ Depends: glib-networking,
          libayatana-appindicator3-1,
          libgtkmm-3.0-1v5,
          libwebkit2gtk-4.0-37
+         libcanberra0
 Description: An unofficial WhatsApp desktop application for linux


### PR DESCRIPTION
This change specifies `libcanberra0` as an installation dependency; otherwise, there is a possibility that it is not installed automatically.

On my system, for example, I installed `whatsapp-for-linux` and its dependencies with `apt --no-install-recommends`, without any errors during installation. However, when I launched the app, it exited with an error: `whatsapp-for-linux: error while loading shared libraries: libcanberra.so.0: cannot open shared object file: No such file or directory`. That got sorted by installing `libcanberra0`

My machine is currently running Debian 12 "Bookworm" (Testing release). Note: Most packages I have installed manually have been installed with `apt --no-install-recommends`
