### PR TITLE
added function to handle version command line argument. Fixes #352

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,10 @@
 #include "Config.hpp"
 #include "ui/Application.hpp"
 #include "util/Helper.hpp"
+#include <gtkmm/main.h>
+#include <glibmm/optioncontext.h>
+#include <glibmm/optiongroup.h>
+#include <iostream>
 
 namespace
 {
@@ -12,6 +16,23 @@ namespace
     }
 }
 
+void handleVersionCommandLineOption(int argc, char** argv, bool& version)
+{
+    Glib::OptionGroup   optionGroup("options", "Command Line Options", "Show command line options");
+    Glib::OptionContext optionContext;
+
+    Glib::OptionEntry versionEntry;
+    versionEntry.set_long_name("version");
+    versionEntry.set_short_name('v');
+    versionEntry.set_description("Show the version of the program");
+    versionEntry.set_arg_description("VERSION");
+    optionGroup.add_entry(versionEntry, version);
+
+    optionContext.set_main_group(optionGroup);
+
+    Gtk::Main kit(argc, argv, optionContext);
+}
+
 int main(int argc, char** argv)
 {
     setlocale(LC_ALL, "");
@@ -19,6 +40,15 @@ int main(int argc, char** argv)
     bindtextdomain(GETTEXT_PACKAGE, WFL_LOCALEDIR);
     bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
     textdomain(GETTEXT_PACKAGE);
+
+    bool version = false;
+    handleVersionCommandLineOption(argc, argv, version);
+
+    if (version)
+    {
+        std::cout << "Version: " << WFL_VERSION << std::endl;
+        return 0;
+    }
 
     auto app = wfl::ui::Application{argc, argv};
 


### PR DESCRIPTION
Fixes #352 

**Proposed Changes**
 - Added a function `handleVersionCommandLineOption` to handle the `--version` and `-v` command line options.
