### PR TITLE
Set user agent to a valid Google Chrome release

### DIFF
--- a/src/ui/WebView.cpp
+++ b/src/ui/WebView.cpp
@@ -14,6 +14,7 @@ namespace wfl::ui
     namespace
     {
         constexpr auto const WHATSAPP_WEB_URI = "https://web.whatsapp.com";
+        constexpr auto const USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 
         std::optional<std::string> getSystemLanguage()
         {
@@ -186,6 +187,7 @@ namespace wfl::ui
         }
 
         auto const settings = webkit_web_view_get_settings(*this);
+        webkit_settings_set_user_agent(settings, USER_AGENT);
         webkit_settings_set_enable_developer_extras(settings, TRUE);
         auto hwAccelPolicy = static_cast<WebKitHardwareAccelerationPolicy>(util::Settings::getInstance().getValue<int>("web", "hw-accel", 1));
         webkit_settings_set_hardware_acceleration_policy(settings, hwAccelPolicy);


### PR DESCRIPTION
WhatsApp was complaining that the Chrome version was too old, and did not let us use it. To fix it, just use the latest Google Chrome user agent grabbed straight from a running browser :)

This was the latest version as of 20/01/24.

Fixes #360