### PR TITLE
Adding custom.css

### DIFF
--- a/src/ui/WebView.cpp
+++ b/src/ui/WebView.cpp
@@ -175,8 +175,8 @@ namespace wfl::ui
     {
         auto const webContext = webkit_web_view_get_context(*this);
 
-        std::string configDir   = Glib::get_user_config_dir();
-        std::string cssFilePath = configDir + "/" + WFL_NAME + "/web.css";
+        auto configDir   = Glib::get_user_config_dir();
+        auto cssFilePath = configDir + "/" + WFL_NAME + "/web.css";
 
         g_signal_connect(*this, "load-changed", G_CALLBACK(detail::loadChanged), this);
         g_signal_connect(*this, "permission-request", G_CALLBACK(permissionRequest), nullptr);
@@ -270,32 +270,28 @@ namespace wfl::ui
 
     bool WebView::cssFileExists(const std::string& filePath)
     {
-        std::ifstream file(filePath);
+        auto file = std::ifstream(filePath);
         return file.good();
     }
 
     std::string WebView::loadCssContent(const std::string& cssFilePath)
     {
-        std::ifstream cssFile(cssFilePath);
-        std::string   cssContent((std::istreambuf_iterator<char>(cssFile)), std::istreambuf_iterator<char>());
+        auto cssFile    = std::ifstream(cssFilePath);
+        auto cssContent = std::string((std::istreambuf_iterator<char>(cssFile)), std::istreambuf_iterator<char>());
 
         return cssContent;
     }
 
     void WebView::applyCustomCss(const std::string& cssFilePath)
     {
-        std::string cssContent = loadCssContent(cssFilePath);
+        auto cssContent = loadCssContent(cssFilePath);
 
-        // Create the WebKitUserStyleSheet
-        WebKitUserStyleSheet* styleSheet
+        auto* styleSheet
             = webkit_user_style_sheet_new(cssContent.c_str(), WEBKIT_USER_CONTENT_INJECT_ALL_FRAMES, WEBKIT_USER_STYLE_LEVEL_USER, nullptr, /* whitelist */
                 nullptr                                                                                                                     /* blacklist */
             );
 
-        // Get the WebKitUserContentManager from the web view
-        WebKitUserContentManager* manager = webkit_web_view_get_user_content_manager(*this);
-
-        // Add the stylesheet to the content manager
+        auto* manager = webkit_web_view_get_user_content_manager(*this);
         webkit_user_content_manager_add_style_sheet(manager, styleSheet);
     }
 

--- a/src/ui/WebView.cpp
+++ b/src/ui/WebView.cpp
@@ -175,8 +175,8 @@ namespace wfl::ui
     {
         auto const webContext = webkit_web_view_get_context(*this);
 
-        auto std::string configDir = Glib::get_user_config_dir();
-        auto std::string cssFilePath = configDir +  "/" + WFL_NAME + "/web.css";
+        std::string configDir   = Glib::get_user_config_dir();
+        std::string cssFilePath = configDir + "/" + WFL_NAME + "/web.css";
 
         g_signal_connect(*this, "load-changed", G_CALLBACK(detail::loadChanged), this);
         g_signal_connect(*this, "permission-request", G_CALLBACK(permissionRequest), nullptr);
@@ -268,20 +268,22 @@ namespace wfl::ui
         sendRequest("whatsapp://send?phone=" + phoneNumber);
     }
 
-    bool WebView::cssFileExists(const std::string& filePath) {
+    bool WebView::cssFileExists(const std::string& filePath)
+    {
         std::ifstream file(filePath);
         return file.good();
     }
 
-    std::string WebView::loadCssContent(const std::string& cssFilePath) {
-        auto std::ifstream cssFile(cssFilePath);
-        auto std::string cssContent((std::istreambuf_iterator<char>(cssFile)),
-                                std::istreambuf_iterator<char>());
+    std::string WebView::loadCssContent(const std::string& cssFilePath)
+    {
+        std::ifstream cssFile(cssFilePath);
+        std::string   cssContent((std::istreambuf_iterator<char>(cssFile)), std::istreambuf_iterator<char>());
 
         return cssContent;
     }
 
-    void WebView::applyCustomCss(const std::string& cssFilePath) {
+    void WebView::applyCustomCss(const std::string& cssFilePath)
+    {
         std::string cssContent = loadCssContent(cssFilePath);
 
         // Create the WebKitUserStyleSheet

--- a/src/ui/WebView.cpp
+++ b/src/ui/WebView.cpp
@@ -287,13 +287,10 @@ namespace wfl::ui
         std::string cssContent = loadCssContent(cssFilePath);
 
         // Create the WebKitUserStyleSheet
-        WebKitUserStyleSheet* styleSheet = webkit_user_style_sheet_new(
-            cssContent.c_str(),
-            WEBKIT_USER_CONTENT_INJECT_ALL_FRAMES,
-            WEBKIT_USER_STYLE_LEVEL_USER,
-            nullptr, /* whitelist */
-            nullptr  /* blacklist */
-        );
+        WebKitUserStyleSheet* styleSheet
+            = webkit_user_style_sheet_new(cssContent.c_str(), WEBKIT_USER_CONTENT_INJECT_ALL_FRAMES, WEBKIT_USER_STYLE_LEVEL_USER, nullptr, /* whitelist */
+                nullptr                                                                                                                     /* blacklist */
+            );
 
         // Get the WebKitUserContentManager from the web view
         WebKitUserContentManager* manager = webkit_web_view_get_user_content_manager(*this);

--- a/src/ui/WebView.cpp
+++ b/src/ui/WebView.cpp
@@ -175,8 +175,8 @@ namespace wfl::ui
     {
         auto const webContext = webkit_web_view_get_context(*this);
 
-        std::string configDir = Glib::get_user_config_dir();
-        std::string cssFilePath = configDir +  "/" + WFL_NAME + "/custom.css";
+        auto std::string configDir = Glib::get_user_config_dir();
+        auto std::string cssFilePath = configDir +  "/" + WFL_NAME + "/web.css";
 
         g_signal_connect(*this, "load-changed", G_CALLBACK(detail::loadChanged), this);
         g_signal_connect(*this, "permission-request", G_CALLBACK(permissionRequest), nullptr);
@@ -202,7 +202,8 @@ namespace wfl::ui
 
         webkit_web_view_set_zoom_level(*this, util::Settings::getInstance().getValue<double>("general", "zoom-level", 1.0));
 
-        if (cssFileExists(cssFilePath)) {
+        if (cssFileExists(cssFilePath))
+        {
             applyCustomCss(cssFilePath);
         }
 
@@ -273,8 +274,8 @@ namespace wfl::ui
     }
 
     std::string WebView::loadCssContent(const std::string& cssFilePath) {
-        std::ifstream cssFile(cssFilePath);
-        std::string cssContent((std::istreambuf_iterator<char>(cssFile)),
+        auto std::ifstream cssFile(cssFilePath);
+        auto std::string cssContent((std::istreambuf_iterator<char>(cssFile)),
                                 std::istreambuf_iterator<char>());
 
         return cssContent;

--- a/src/ui/WebView.cpp
+++ b/src/ui/WebView.cpp
@@ -1,13 +1,17 @@
 #include "WebView.hpp"
 #include <iostream>
 #include <string>
+#include <fstream>
+#include <streambuf>
 #include <optional>
 #include <locale>
 #include <glibmm/i18n.h>
 #include <glibmm/main.h>
+#include <glibmm/miscutils.h>
 #include <gtkmm/messagedialog.h>
 #include <gtkmm/filechooserdialog.h>
 #include "../util/Settings.hpp"
+#include "Config.hpp"
 
 namespace wfl::ui
 {
@@ -171,6 +175,9 @@ namespace wfl::ui
     {
         auto const webContext = webkit_web_view_get_context(*this);
 
+        std::string configDir = Glib::get_user_config_dir();
+        std::string cssFilePath = configDir +  "/" + WFL_NAME + "/custom.css";
+
         g_signal_connect(*this, "load-changed", G_CALLBACK(detail::loadChanged), this);
         g_signal_connect(*this, "permission-request", G_CALLBACK(permissionRequest), nullptr);
         g_signal_connect(*this, "decide-policy", G_CALLBACK(decidePolicy), nullptr);
@@ -194,6 +201,10 @@ namespace wfl::ui
         webkit_settings_set_minimum_font_size(settings, util::Settings::getInstance().getValue<int>("web", "min-font-size", 0));
 
         webkit_web_view_set_zoom_level(*this, util::Settings::getInstance().getValue<double>("general", "zoom-level", 1.0));
+
+        if (cssFileExists(cssFilePath)) {
+            applyCustomCss(cssFilePath);
+        }
 
         webkit_web_view_load_uri(*this, WHATSAPP_WEB_URI);
     }
@@ -254,6 +265,38 @@ namespace wfl::ui
     void WebView::openPhoneNumber(std::string const& phoneNumber)
     {
         sendRequest("whatsapp://send?phone=" + phoneNumber);
+    }
+
+    bool WebView::cssFileExists(const std::string& filePath) {
+        std::ifstream file(filePath);
+        return file.good();
+    }
+
+    std::string WebView::loadCssContent(const std::string& cssFilePath) {
+        std::ifstream cssFile(cssFilePath);
+        std::string cssContent((std::istreambuf_iterator<char>(cssFile)),
+                                std::istreambuf_iterator<char>());
+
+        return cssContent;
+    }
+
+    void WebView::applyCustomCss(const std::string& cssFilePath) {
+        std::string cssContent = loadCssContent(cssFilePath);
+
+        // Create the WebKitUserStyleSheet
+        WebKitUserStyleSheet* styleSheet = webkit_user_style_sheet_new(
+            cssContent.c_str(),
+            WEBKIT_USER_CONTENT_INJECT_ALL_FRAMES,
+            WEBKIT_USER_STYLE_LEVEL_USER,
+            nullptr, /* whitelist */
+            nullptr  /* blacklist */
+        );
+
+        // Get the WebKitUserContentManager from the web view
+        WebKitUserContentManager* manager = webkit_web_view_get_user_content_manager(*this);
+
+        // Add the stylesheet to the content manager
+        webkit_user_content_manager_add_style_sheet(manager, styleSheet);
     }
 
     void WebView::zoomIn()

--- a/src/ui/WebView.hpp
+++ b/src/ui/WebView.hpp
@@ -30,6 +30,9 @@ namespace wfl::ui
             double          getZoomLevel();
             std::string     getZoomLevelString();
             void            setMinFontSize(unsigned int fontSize);
+            bool            cssFileExists(const std::string& filePath);
+            std::string     loadCssContent(const std::string& cssFilePath);
+            void            applyCustomCss(const std::string& cssFilePath);
 
             sigc::signal<void, WebKitLoadEvent>& signalLoadStatus() noexcept;
             sigc::signal<void, bool>&            signalNotification() noexcept;


### PR DESCRIPTION
since this was a highly requested feature i thought of implementing it. i think some of the code might belong to the utils but i guess you should decide instead. to test it:

* add `custom.css` to `~/.config/whatsapp-for-linux`
* fill it with `* { color: red !important }`
